### PR TITLE
Added support for disabled logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All the options will be passed into `nw-builder` directly except `files`.
 
 For detail description, see: [Options](https://github.com/nwjs/nw-builder/blob/master/README.md)
 
+Additionally, `quiet: true` will disable all logging to gulp.
 
 ## LICENSE
 

--- a/index.js
+++ b/index.js
@@ -26,10 +26,14 @@ var gulpNodeWebkitBuilder = function(opts) {
 
         var nw = new NwBuilder(options);
 
-        nw.on('log', gutil.log);
+        if(!options.quiet) {
+            nw.on('log', gutil.log);
+        }
 
         nw.build().then(function() {
-            gutil.log('all done!');
+            if(!options.quiet) {
+                gutil.log('all done!');
+            }
             cb();
         }).catch(function(err) {
             _this.emit('error', new PluginError(PLUGIN_NAME, 'Error occured while building app!'));


### PR DESCRIPTION
nw-builder supports `--quiet` in the CLI interface, so I figured the gulp interface should support the same functionality. I, for one, like a nice clean gulp log. :]
